### PR TITLE
ensure lock file does not change

### DIFF
--- a/.github/workflows/yarn-test.yml
+++ b/.github/workflows/yarn-test.yml
@@ -13,7 +13,7 @@ jobs:
           cache: "yarn"
           node-version: "20.5.0"
       - name: Install dependencies
-        run: yarn
+        run: yarn --frozen-lockfile
       - name: Lint
         run: yarn lint:check
       - name: Test


### PR DESCRIPTION
Run yarn with the `--frozen-lockfile` flag on CI, which will fail if the yarn.lock would be modified. This ensures we always check in the latest `yarn.lock`.