### PR TITLE
Simplify HTLC

### DIFF
--- a/contracts/state.sol
+++ b/contracts/state.sol
@@ -10,8 +10,13 @@ struct State {
     HTLC[] htlcs;
 }
 
+enum Payee {
+    OWNER,
+    INTERMEDIARY
+}
+
 struct HTLC {
-    address payable to;
+    Payee to;
     uint amount;
     bytes32 hashLock;
     uint timelock;

--- a/test/Nitro-SCW.ts
+++ b/test/Nitro-SCW.ts
@@ -1,13 +1,15 @@
 import hre, { ethers } from 'hardhat'
 import { NitroSmartContractWallet__factory, type NitroSmartContractWallet } from '../typechain-types'
 import { type BaseWallet } from 'ethers'
-import { type StateStruct, type UserOperationStruct } from '../typechain-types/Nitro-SCW.sol/NitroSmartContractWallet'
+
 import { expect } from 'chai'
 import { getUserOpHash, signUserOp } from './UserOp'
 import { signStateHash } from './State'
 import { time } from '@nomicfoundation/hardhat-network-helpers'
+import { type UserOperationStruct, type StateStruct } from '../typechain-types/contracts/Nitro-SCW.sol/NitroSmartContractWallet'
 const ONE_DAY = 86400
 const TIMELOCK_DELAY = 1000
+const enum Payee { Owner = 0, Intermediary = 1 }
 async function getBlockTimestamp (): Promise<number> {
   const blockNum = await hre.ethers.provider.getBlockNumber()
   const block = await hre.ethers.provider.getBlock(blockNum)
@@ -53,7 +55,7 @@ describe('Nitro-SCW', function () {
         htlcs: [
           {
             amount: 0,
-            to: intermediary.address,
+            to: Payee.Intermediary,
             hashLock: hash,
             timelock: (await getBlockTimestamp()) + TIMELOCK_DELAY
           }
@@ -92,7 +94,7 @@ describe('Nitro-SCW', function () {
         htlcs: [
           {
             amount: 0,
-            to: intermediary.address,
+            to: Payee.Intermediary,
             hashLock: hash,
             timelock: (await getBlockTimestamp()) + 1000
           }


### PR DESCRIPTION
Simplifies the HTLC by using an enum for `to` field instead of full addresses. We already had a `require` statement enforcing that `to` was either the owner or intermediary.