### PR TITLE
specify yarn version

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint:write": "eslint . --ext ts --fix",
     "prepack": "yarn build"
   },
+  "packageManager": "yarn@1.22.19",
   "devDependencies": {
     "@nomicfoundation/hardhat-chai-matchers": "^2.0.0",
     "@nomicfoundation/hardhat-ethers": "^3.0.0",
@@ -42,6 +43,5 @@
     "ts-node": ">=8.0.0",
     "typechain": "^8.1.0",
     "typescript": ">=4.5.0"
-  },
-  "dependencies": {}
+  }
 }


### PR DESCRIPTION
This is according to `corepack` spec, and in accordance with at least two people running this version of yarn locally.

With this modification, my local `yarn install`s no longer introduce changes.