### PR TITLE
Simplify HTLCs in ts client

### DIFF
--- a/clients/StateChannelWallet.ts
+++ b/clients/StateChannelWallet.ts
@@ -50,6 +50,11 @@ export class StateChannelWallet {
     return Number(this.intermediaryBalance)
   }
 
+  async getOwnerBalance (): Promise<number> {
+    const walletBalance = await this.getBalance();
+    return walletBalance - await this.getIntermediaryBalance();
+  }
+
   async getCurrentBlockNumber (): Promise<number> {
     const blockNumber = await this.chainProvider.getBlockNumber()
     return blockNumber

--- a/clients/StateChannelWallet.ts
+++ b/clients/StateChannelWallet.ts
@@ -103,8 +103,12 @@ export class StateChannelWallet {
   // Craft an HTLC struct, put it inside a state, hash the state, sign and return it
   async createHTLCPayment (toAddress: string, amount: number, hash: string): Promise<string> {
     const currentTimestamp: number = Math.floor(Date.now() / 1000) // Unix timestamp in seconds
+    if (toAddress === this.signer.address) {
+      throw new Error('Cannot create HTLC to self')
+    }
+
     const htlc: HTLCStruct = {
-      to: toAddress,
+      to: this.theirRole(),
       amount,
       hashLock: hash,
       timelock: currentTimestamp + HTLC_TIMEOUT * 2 // payment creator always uses TIMEOUT * 2

--- a/clients/StateChannelWallet.ts
+++ b/clients/StateChannelWallet.ts
@@ -52,8 +52,8 @@ export class StateChannelWallet {
   }
 
   async getOwnerBalance (): Promise<number> {
-    const walletBalance = await this.getBalance();
-    return walletBalance - await this.getIntermediaryBalance();
+    const walletBalance = await this.getBalance()
+    return walletBalance - await this.getIntermediaryBalance()
   }
 
   async getCurrentBlockNumber (): Promise<number> {

--- a/clients/StateChannelWallet.ts
+++ b/clients/StateChannelWallet.ts
@@ -1,5 +1,5 @@
 import { ethers } from 'ethers'
-import { type UserOperationStruct, type HTLCStruct, type StateStruct, type NitroSmartContractWallet } from '../typechain-types/Nitro-SCW.sol/NitroSmartContractWallet'
+import { type UserOperationStruct, type HTLCStruct, type StateStruct, type NitroSmartContractWallet } from '../typechain-types/contracts/Nitro-SCW.sol/NitroSmartContractWallet'
 import { signUserOp } from './UserOp'
 import { NitroSmartContractWallet__factory } from '../typechain-types'
 

--- a/clients/StateChannelWallet.ts
+++ b/clients/StateChannelWallet.ts
@@ -41,6 +41,7 @@ export class StateChannelWallet {
   }
 
   async getBalance (): Promise<number> {
+    // todo: caching, block event based updating, etc
     const balance = await this.chainProvider.getBalance(this.scwAddress)
     const balanceEther = ethers.formatEther(balance)
     return Number(balanceEther)

--- a/contracts/Nitro-SCW.sol
+++ b/contracts/Nitro-SCW.sol
@@ -5,7 +5,7 @@ pragma solidity 0.8.19;
 import {IAccount} from "contracts/interfaces/IAccount.sol";
 import {UserOperation} from "contracts/interfaces/UserOperation.sol";
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
-import {HTLC, State, hashState, checkSignatures, Payee} from "./state.sol";
+import {HTLC, State, hashState, checkSignatures, Participant} from "./state.sol";
 enum WalletStatus {
     OPEN,
     CHALLENGE_RAISED,
@@ -47,7 +47,7 @@ contract NitroSmartContractWallet is IAccount {
 
         removeActiveHTLC(hashLock);
 
-        if (htlc.to == Payee.INTERMEDIARY) {
+        if (htlc.to == Participant.INTERMEDIARY) {
             intermediaryBalance += htlc.amount;
         }
     }
@@ -73,7 +73,7 @@ contract NitroSmartContractWallet is IAccount {
         // Release any expired funds back to the sender
         for (uint i = 0; i < activeHTLCs.length; i++) {
             HTLC memory htlc = htlcs[activeHTLCs[i]];
-            if (htlc.to == Payee.OWNER) {
+            if (htlc.to == Participant.OWNER) {
                 intermediary.transfer(htlc.amount);
             } else {
                 owner.transfer(htlc.amount);

--- a/contracts/state.sol
+++ b/contracts/state.sol
@@ -10,13 +10,13 @@ struct State {
     HTLC[] htlcs;
 }
 
-enum Payee {
+enum Participant {
     OWNER,
     INTERMEDIARY
 }
 
 struct HTLC {
-    Payee to;
+    Participant to;
     uint amount;
     bytes32 hashLock;
     uint timelock;

--- a/test/Nitro-SCW.ts
+++ b/test/Nitro-SCW.ts
@@ -9,7 +9,7 @@ import { time } from '@nomicfoundation/hardhat-network-helpers'
 import { type UserOperationStruct, type StateStruct } from '../typechain-types/contracts/Nitro-SCW.sol/NitroSmartContractWallet'
 const ONE_DAY = 86400
 const TIMELOCK_DELAY = 1000
-const enum Payee { Owner = 0, Intermediary = 1 }
+const enum Participant { Owner = 0, Intermediary = 1 }
 async function getBlockTimestamp (): Promise<number> {
   const blockNum = await hre.ethers.provider.getBlockNumber()
   const block = await hre.ethers.provider.getBlock(blockNum)
@@ -54,7 +54,7 @@ describe('Nitro-SCW', function () {
         htlcs: [
           {
             amount: 0,
-            to: Payee.Intermediary,
+            to: Participant.Intermediary,
             hashLock: ethers.ZeroHash,
             timelock: (await getBlockTimestamp()) + 1000
           }
@@ -78,7 +78,7 @@ describe('Nitro-SCW', function () {
         htlcs: [
           {
             amount: 0,
-            to: Payee.Intermediary,
+            to: Participant.Intermediary,
             hashLock: ethers.ZeroHash,
             timelock: (await getBlockTimestamp()) + 1000
           }
@@ -106,7 +106,7 @@ describe('Nitro-SCW', function () {
         htlcs: [
           {
             amount: 0,
-            to: Payee.Intermediary,
+            to: Participant.Intermediary,
             hashLock: hash,
             timelock: (await getBlockTimestamp()) + TIMELOCK_DELAY
           }
@@ -142,7 +142,7 @@ describe('Nitro-SCW', function () {
         htlcs: [
           {
             amount: 0,
-            to: Payee.Intermediary,
+            to: Participant.Intermediary,
             hashLock: hash,
             timelock: (await getBlockTimestamp()) + 1000
           }


### PR DESCRIPTION
PR follows work from #27 , where `address payable` was replaced with a designated `owner`/`intermediary` enum target.

Quirks in typechain allowed this to be ignored - it seems that both `address payable` and `enum` convert to TS `BigNumberish`.