### PR TITLE
add LockedUserOps skeleton

### DIFF
--- a/contracts/LockedUserOps.sol
+++ b/contracts/LockedUserOps.sol
@@ -1,0 +1,69 @@
+pragma solidity 0.8.19;
+
+import {UserOperation} from "contracts/interfaces/UserOperation.sol";
+import {IEntryPoint} from "contracts/interfaces/IEntryPoint.sol";
+
+struct LockedOp {
+  UserOperation userOp;
+  uint256 expiry;
+  // uint256 value; // todo
+}
+
+contract LockedUserOps {
+  mapping(bytes32 => LockedOp) public lockedUserOps;
+  IEntryPoint public entryPoint;
+
+  constructor(IEntryPoint _entryPoint) {
+    entryPoint = _entryPoint;
+  }
+
+  /**
+   * @dev Register a UserOperation that can be released by the user.
+   * @param hashlock - Hashlock of the UserOperation
+   * @param userOp - UserOperation to be registered
+   */
+  function registerUserOp(
+    bytes32 hashlock,
+    LockedOp memory userOp
+  ) public payable {
+    require(userOp.expiry > block.timestamp, "UserOp already expired");
+    require(lockedUserOps[hashlock].expiry == 0, "UserOp already registered");
+
+    lockedUserOps[hashlock] = userOp;
+    // todo: account for transferred `value`
+  }
+
+  function releaseSHAuserOp(bytes calldata preimage) public {
+    // check
+    bytes32 hashlock = sha256(preimage);
+    LockedOp memory lockedOp = lockedUserOps[hashlock];
+    require(lockedOp.expiry > 0, "UserOp not found");
+
+    // effect
+    delete lockedUserOps[hashlock];
+
+    // interaction
+    // todo: pass in required `value` / `gas` parameters
+    executeUserOp(lockedOp.userOp);
+  }
+
+  function releaseUserOp(bytes calldata preimage) public {
+    // check
+    bytes32 hashlock = keccak256(preimage);
+    LockedOp memory lockedOp = lockedUserOps[hashlock];
+    require(lockedOp.expiry > 0, "UserOp not found");
+
+    // effect
+    delete lockedUserOps[hashlock];
+
+    // interaction
+    // todo: pass in required `value` / `gas` parameters
+    executeUserOp(lockedOp.userOp);
+  }
+
+  function executeUserOp(UserOperation memory userOp) internal {
+    UserOperation[] memory ops = new UserOperation[](1);
+    ops[0] = userOp;
+    entryPoint.handleOps(ops, payable(msg.sender));
+  }
+}

--- a/contracts/LockedUserOps.sol
+++ b/contracts/LockedUserOps.sol
@@ -10,6 +10,8 @@ struct LockedOp {
 }
 
 contract LockedUserOps {
+  event UserOpRegistered(bytes32 indexed hashlock, LockedOp userOp);
+
   mapping(bytes32 => LockedOp) public lockedUserOps;
   IEntryPoint public entryPoint;
 
@@ -30,6 +32,7 @@ contract LockedUserOps {
     require(lockedUserOps[hashlock].expiry == 0, "UserOp already registered");
 
     lockedUserOps[hashlock] = userOp;
+    emit UserOpRegistered(hashlock, userOp);
     // todo: account for transferred `value`
   }
 


### PR DESCRIPTION
This is a sketch / skeleton for queuing `UserOperations` that originate from a bridge-wallet on another chain.

Target branch is `rpc`.